### PR TITLE
implemented realip v2.5 support

### DIFF
--- a/protocol/handshaking/serverbound_handshake_test.go
+++ b/protocol/handshaking/serverbound_handshake_test.go
@@ -323,7 +323,7 @@ func TestServerBoundHandshake_UpgradeToRealIP(t *testing.T) {
 
 	for _, tc := range tt {
 		hs := ServerBoundHandshake{ServerAddress: protocol.String(tc.addr)}
-		hs.UpgradeToRealIP(&tc.clientAddr, tc.timestamp)
+		hs.UpgradeToRealIP(tc.clientAddr.String(), tc.timestamp)
 
 		if hs.ParseServerAddress() != tc.addr {
 			t.Errorf("got: %v; want: %v", hs.ParseServerAddress(), tc.addr)


### PR DESCRIPTION
Add these to your config files of the servers you want to use them on
```
"realIp2.5": true,
"keyPath": "/path/to/key",
```
and make sure that the original real ip config value isnt set to true